### PR TITLE
BUG: Do not try to find dlfcn.h

### DIFF
--- a/CMake/sitkTargetLinkLibrariesWithDynamicLookup.cmake
+++ b/CMake/sitkTargetLinkLibrariesWithDynamicLookup.cmake
@@ -318,12 +318,6 @@ function(_test_weak_link_project
       #include <number.h>
     ")
 
-    if(NOT link_exe_mod)
-      file(APPEND "${test_project_src_dir}/main.c" "
-        #include <dlfcn.h>
-      ")
-    endif()
-
     file(APPEND "${test_project_src_dir}/main.c" "
       int my_count() {
         int result = get_number();


### PR DESCRIPTION
Removing include since this breaks the build for a lot of users (which is weird because it is in a CMake test