### PR TITLE
DOCS: update groupwise registration extraction, transformix on labels, and Sphinx building

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -13,6 +13,14 @@ and run the following make command in `Documentation/`:
 $ make html
 ```
 
+If you are building docs in a Python environment, you can install packages through pip and run `sphinx-build` directly:
+
+```bash
+$ pip install sphinx
+$ pip install sphinx_rtd_theme
+$ sphinx-build -b html Sphinx build
+```
+
 The docs will be generated and the output files will be placed in the `build/html/` directory which can be browsed (locally) with your favorite browser. The documentation can be automatically regenerated whenever a file changes (useful for development) using `sphinx-autobuild`:
 
 ```bash

--- a/Documentation/Sphinx/GroupwiseRegistration.rst
+++ b/Documentation/Sphinx/GroupwiseRegistration.rst
@@ -42,6 +42,21 @@ Elastix takes a single N+1 dimensional image for groupwise registration. Therefo
 
 While the groupwise transform works only on the moving image we need to pass a dummy fixed image is to prevent elastix from throwing errors. This does not consume extra memory as only pointers are passed internally. 
 
+The resulting image individual groupwise-registered images can be obtained with an image extract filter:
+
+::
+    
+    transformed_img = elastix_img_filter.GetResultImage()
+    extract_filter = sitk.ExtractImageFilter()
+    size = list(transformed_img.GetSize())
+    size[3] = 0 # set t to 0 to collapse this dimension
+    extract_filter.SetSize(size)
+    imgs = []
+    for i in range(len(imgs_orig)):
+        extract_filter.SetIndex([0, 0, 0, i]) # x, y, z, t
+        img = extract_filter.Execute(transformed_img)
+        imgs.append(sitk.GetArrayFromImage(img))
+
 The result image is shown in Figure 13. It is clear that anatomical correpondence is obtained in many regions of the brain. However, there are a some anatomical regions that have not been registered correctly, particularly near Corpus Collosum. Generally these kinds of difficult registration problems require a lot of parameter tuning. No way around that. In a later chapter we introduce methods for assessment of registration quality.
 
 .. figure:: _static/PostGroupwise.jpg
@@ -49,7 +64,7 @@ The result image is shown in Figure 13. It is clear that anatomical correpondenc
     :figwidth: 90%
     :width: 75% 
 
-    Figure 13: Mean result image. 
+    Figure 13: Overlaid resulting images. 
 
 .. tip::
 

--- a/Documentation/Sphinx/HelloWorld.rst
+++ b/Documentation/Sphinx/HelloWorld.rst
@@ -90,6 +90,17 @@ This is more verbose but also a lot more powerful. We can now warp an entire pop
         transformixImageFilter.Execute()
         sitk.WriteImage(transformixImageFilter.GetResultImage(), "result_"+filename)
 
+.. tip::
+    
+    For labels images, where the exact numerical intensity values should be preserved, the `FinalBSplineInterpolationOrder` needs to be set to 0 in the transform parameter file (see see section 4.3 of the Elastix manual):
+    
+    ::
+        
+        # turn off FinalBSplineInterpolationOrder in the final map to avoid 
+        # overshooting the interpolation for the labels image 
+        transform_param_map = elastix_img_filter.GetTransformParameterMap()
+        transform_param_map[-1]["FinalBSplineInterpolationOrder"] = ["0"]
+
 The object-oriented interface facilitates reuse of components and dramatically simplifies book-keeping and boilerplate code. We will use the object-oriented interface in the documentation from this point forward.
 
 In the next section, we will take a closer look at the parameter map interface that configures the registration components.


### PR DESCRIPTION
This update provides a few clarifications for relatively new users of Elastix/SimpleElastix (like me). I've attempted to provide some sample code to extend and clarify concepts mentioned in the current docs in these areas:

- How to use `ExtractImageFilter` to extract individual resulting images from a groupwise registration (see discussion in #186 )
- Set `FinalBSplineInterpolationOrder` when applying Transformix to labels images (see #205 )
- Instructions for installing and running Sphinx within a Python environment, which also bypasses a Makefile error where the source directory is not found (at least in my environment)

I hope these docs updates may help other novice users like myself, and I'd appreciate review to ensure that the sample code represents the optimal way to tackle these registration steps. Thanks for this awesome tool!