### PR TITLE
CI: Drop build of Python 3.5 to speed up CI

### DIFF
--- a/Testing/CI/Azure/ci.yml
+++ b/Testing/CI/Azure/ci.yml
@@ -10,8 +10,6 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
@@ -56,8 +54,6 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
@@ -98,8 +94,6 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:


### PR DESCRIPTION
Azure proviedes 10 concurrent builds while we built 12 (Windows, Mac, Linux, Python 2.7, 3.5, 3.6, 3.7). Without the Python 3.5 build we build 9 different version of SimpleElastix and can do it in one round.