### PR TITLE
DOC : Fix virtual env doc

### DIFF
--- a/Documentation/Sphinx/GettingStarted.rst
+++ b/Documentation/Sphinx/GettingStarted.rst
@@ -10,6 +10,10 @@ This page explains how to install SimpleElastix. The process involves compiling 
 Compiling On Linux
 -------------------
 
+.. warning::
+
+    Make sure to have the sudo rights to install SimpleElastix
+
 SimpleElastix includes a script that automatically downloads and installs all dependencies. This is called a 'SuperBuild' in CMake terms. We only need CMake, git, and a compiler toolchain to compile the SuperBuild. Once these have been installed (e.g. :code:`sudo apt install cmake git build-essential`), we use the following commands to download the code and start the build:
 
 ::
@@ -42,15 +46,33 @@ To install the python module onto your system, navigate to
 
     ${BUILD_DIRECTORY}/SimpleITK-build/Wrapping/Python
 
-and run the following command:
+## With virtual environment
+
+First, load the virtual environment and run the following command :
+
+::
+
+    $ python Packaging/setup.py install
+
+This will install the SimpleElastix in your virtual environment which we can then import into our own scripts.
+
+## Without virtual environment
+
+.. warning::
+
+    The following command install by default the SimpleElastix in python2 default environment if we want to install
+    in pyhton3 default environment we will have to :code:`python` to :code:`python3` in the following command
+
+Run the following command :
 
 ::
 
     $ sudo python Packaging/setup.py install
 
-This will install the SimpleElastix which we can then import into our own scripts. If we want to install SimpleElastix into a virtual environment, activate the virtual environment on beforehand and omit :code:`sudo`. If you don't know what a virtual environment is, don't worry about it, it is entirely optional.
+This will install the SimpleElastix in your python default environment which we can then import into our own scripts.
 
 # Java
+
 TODO: Pull request welcome.
 
 # R


### PR DESCRIPTION
Good evening,

I have been a beta tester of SimpleElastix for a workshop organized by Emanoel Sabidussi with the help Stefan Klein. I found the Compiling On Linux documentation a bit tricky about virtual environment. Indeed, if you follow the documentation blindely copy pasting commands as the following "sudo python Packaging/setup.py install" will install SimpleElastix in your default python2 default environment even if your virtual environment is loaded. That's why I proposed a fix on the documentation with two options one with virtual environment and one without. A more global remark I think that it 's better practice to make a warning to explain that sudo rights are required rather than adding "sudo" at the beginning of each command.
Furthermore, my fix is clearly not perfect, it is the first time that I fork a repo and contribute to library so I might have done something wrong. But I hope that what I did can help in a way.

Best
Robin  