### PR TITLE
Update ITK to v5.2.0 to fix error during OpenJPEG build

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -53,7 +53,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "v5.1rc02")
+set(_DEFAULT_ITK_GIT_TAG "v5.2.0")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
This ITK update fixes a build error I encountered on Windows using Microsoft Visual Studio 16.9.3. The error occurs while compiling OpenJPEG for ITK with this message (multiple times):

```
Y:\builds_se_win\build_se_py3.6.8\ITK\Modules\ThirdParty\OpenJPEG\src\openjpeg\opj_includes.h(106,35): error C2169: 'lr
intf': intrinsic function, cannot be defined [Y:\builds_se_win\build_se_py3.6.8\ITK-build\Modules\ThirdParty\OpenJPEG\s
rc\openjpeg\itkopenjpeg.vcxproj] [Y:\builds_se_win\build_se_py3.6.8\ITK.vcxproj]
```

This error appears to the be the same as the one fixed recently in ITK:
https://github.com/InsightSoftwareConsortium/ITK/issues/1967
https://github.com/InsightSoftwareConsortium/ITK/pull/2388

I do not know of a way to pull this fix into SimpleElastix other than to pull in a more recent ITK commit (if there's another way, please let me know!). I simply bumped the tag from v5.1rc02 to v5.2.0 since this appears to be the only tag currently with this fix. I also found this update in SimpleITK (https://github.com/SimpleITK/SimpleITK/pull/1366), so feel free to ignore this PR if upstream SimpleITK will be pulled in anyway.

With this update, the ITK compilation completes. Note that I could not fully complete the SimpleElastix compilation until I also checked out the latest branch here, `update-simpleitk`, which I built on commit 175864a504abb7856432ef0c1308524f83e58f12 , to avoid an Elastix build error.

I also had to use the official Cmake (tested on the latest version, v3.20.0) rather than MSVC Cmake (tested on v3.19.20122902-MSVC_2) to avoid an error when configuring Eigen3, which may be related to these issues:
https://github.com/InsightSoftwareConsortium/ITK/issues/1888
https://github.com/ANTsX/ANTsR/issues/275