### PR TITLE
COMP: Remove danging endif() from azure.cmake

### DIFF
--- a/Testing/CI/Azure/azure.cmake
+++ b/Testing/CI/Azure/azure.cmake
@@ -122,10 +122,6 @@ SET (_dashboard_cache "
 
 set_from_env(dashboard_cache "CTEST_CACHE" DEFAULT ${_dashboard_cache})
 
-endif()
-
-
-
 
 string(TIMESTAMP build_date "%Y-%m-%d")
 message("CDash Build Identifier: ${build_date} ${CTEST_BUILD_NAME}")


### PR DESCRIPTION
Aims to fix a CMake Error from https://dev.azure.com/kaspermarstal/2d67618f-600f-4193-9c0d-bea75ef84a62/_apis/build/builds/2064/logs/25 saying:

> 2021-04-07T06:37:11.4183123Z CMake Error at D:/a/1/s/Testing/CI/Azure/azure.cmake:125 (endif):
> 2021-04-07T06:37:11.4184662Z   Flow control statements are not properly nested.