### PR TITLE
DOC: Fix typos

### DIFF
--- a/Documentation/Sphinx/GroupwiseRegistration.rst
+++ b/Documentation/Sphinx/GroupwiseRegistration.rst
@@ -40,9 +40,9 @@ Elastix takes a single N+1 dimensional image for groupwise registration. Therefo
     elastixImageFilter.SetParameterMap(sitk.GetDefaultParameterMap('groupwise'))
     elastixImageFilter.Execute()
 
-While the groupwise transform works only on the moving image we need to pass a dummy fixed image is to prevent elastix from throwing errors. This does not consume extra memory as only pointers are passed internally. 
+While the groupwise transform works only on the moving image we need to pass a dummy fixed image to prevent elastix from throwing errors. This does not consume extra memory as only pointers are passed internally. 
 
-The result image is shown in Figure 13. It is clear that anatomical correpondence is obtained in many regions of the brain. However, there are a some anatomical regions that have not been registered correctly, particularly near Corpus Collosum. Generally these kinds of difficult registration problems require a lot of parameter tuning. No way around that. In a later chapter we introduce methods for assessment of registration quality.
+The result image is shown in Figure 13. It is clear that anatomical correpondence is obtained in many regions of the brain. However, there are a some anatomical regions that have not been registered correctly, particularly near Corpus Callosum. Generally these kinds of difficult registration problems require a lot of parameter tuning. No way around that. In a later chapter we introduce methods for assessment of registration quality.
 
 .. figure:: _static/PostGroupwise.jpg
     :align: center

--- a/Documentation/Sphinx/PointBasedRegistration.rst
+++ b/Documentation/Sphinx/PointBasedRegistration.rst
@@ -1,7 +1,7 @@
 Point-based Registation
 =======================
 
-Point-based registration allows us to help the registration via pre-defined sets of corresponding points. The :code:`CorrespondingPointsEuclideanDistanceMetric` minimises the distance of between a points on the fixed image and corresponding points on the moving image. The metric can be used to help in a difficult registration task by taking into account positions are known to correspond. Think of it as a way of embedding expert knowledge in the registration procedure. We can manually select points or automatically them via centroids of segmentations for example. Anything is possible.
+Point-based registration allows us to help the registration via pre-defined sets of corresponding points. The :code:`CorrespondingPointsEuclideanDistanceMetric` minimises the distance between points on the fixed image and corresponding points on the moving image. The metric can be used to help in a difficult registration task by taking into account positions that are known to correspond. Think of it as a way of embedding expert knowledge in the registration procedure. We can manually or automatically select points via centroids of segmentations for example. Anything is possible.
 
 To use :code:`CorrespondingPointsEuclideanDistanceMetric` we append it to the list of metrics in the parameter map. 
 


### PR DESCRIPTION
While reading the docs, I've found a few typos and superfluous words. This PR proposes corrections for this. 